### PR TITLE
'or' highlight bug

### DIFF
--- a/Verilog.tmLanguage
+++ b/Verilog.tmLanguage
@@ -298,7 +298,7 @@
 			</dict>
 			<dict>
 				<key>match</key>
-				<string>(!|&amp;&amp;|\|\||\bor\b)</string>
+				<string>(!|&amp;&amp;|\|\|)</string>
 				<key>name</key>
 				<string>keyword.operator.logical.verilog</string>
 			</dict>


### PR DESCRIPTION
The 'or' operator is no a logical operator according to the Verilog standard.
If you wish to keep it in that category bare in mind that the highlight is buggy since every occurence of the string 'or' is highlighted (eg: as part of a identifier 'factor', the 'or' gets highlighted).