### PR TITLE
A better color scheme, closer to sublime default.

### DIFF
--- a/Verilog.tmLanguage
+++ b/Verilog.tmLanguage
@@ -24,7 +24,7 @@
 					<key>1</key>
 					<dict>
 						<key>name</key>
-						<string>storage.type.verilog</string>
+						<string>storage.verilog</string>
 					</dict>
 					<key>2</key>
 					<dict>
@@ -50,12 +50,12 @@
 					<key>2</key>
 					<dict>
 						<key>name</key>
-						<string>entity.name.type.instance.verilog</string>
+						<string>variable.function.verilog</string>
 					</dict>
 					<key>3</key>
 					<dict>
 						<key>name</key>
-						<string>keyword.operator.parenthesis.round.verilog</string>
+						<string>text.operator.parenthesis.round.verilog</string>
 					</dict>
 				</dict>
 				<key>match</key>
@@ -82,7 +82,7 @@
 					<key>3</key> <!-- ( -->
 					<dict>
 						<key>name</key>
-						<string>keyword.operator.parenthesis.round.verilog</string>
+						<string>text.operator.parenthesis.round.verilog</string>
 					</dict>
 					<key>4</key> <!-- something,something -->
 					<dict>
@@ -92,7 +92,7 @@
 					<key>5</key> <!-- ) -->
 					<dict>
 						<key>name</key>
-						<string>keyword.operator.parenthesis.round.verilog</string>
+						<string>text.operator.parenthesis.round.verilog</string>
 					</dict>
 					<key>6</key>
 					<dict>
@@ -102,7 +102,7 @@
 					<key>7</key>
 					<dict>
 						<key>name</key>
-						<string>keyword.operator.parenthesis.round.verilog</string>
+						<string>text.operator.parenthesis.round.verilog</string>
 					</dict>
 				</dict>
 				<key>match</key>
@@ -259,7 +259,7 @@
 				<key>match</key>
 				<string>\b(endmodule|endfunction|endprimitive)\b</string>
 				<key>name</key>
-				<string>storage.type.verilog</string>
+				<string>storage.verilog</string>
 			</dict>
 			<dict>
 				<key>captures</key>
@@ -308,7 +308,7 @@
 				<key>name</key>
 				<string>keyword.operator.bitwise.verilog</string>
 			</dict>				
-			<dict>
+<!-- 			<dict>
 				<key>match</key>
 				<string>({|})</string>
 				<key>name</key>
@@ -331,7 +331,7 @@
 				<string>([;,])</string>
 				<key>name</key>
 				<string>keyword.delimiter.verilog</string>
-			</dict>
+			</dict> -->
 			<dict>
 				<key>match</key>
 				<string>(#|@|=)</string>

--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.0",
+  "schema_version": "2.1",
   "packages": [
     {
       "name": "Sublime Text Verilog",


### PR DESCRIPTION
Made a little modification with the color scheme. Made "module/endmodule" more obvious, made the name of instance of a module different from the name of the module, and remove special color for parenthesis (more consistent with current default of sublime.)